### PR TITLE
1 add visualization for periods that will get skipped

### DIFF
--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -55,6 +55,22 @@ function addRedRectangle(div, percentStart, percentEnd) {
     return redRectangle;//return for future ref
   }
 
+function generateSkipPeriodsVisualization(){
+    const controlBarElement = getVideoSeekBarElement();
+    const captions = getVideoCaptions();
+    const totalVideoTime = getVideoElement().duration;
+    let prevEndTime = 0;
+    for(let i = 0; i < captions.length; i++){
+        const diffToNextCaption = captions[i].startTime - prevEndTime;
+        if(diffToNextCaption > document.MIN_SKIP_TIME_UNTIL_NEXT_CAPTION){
+            // if will be skipped
+            addRedRectangle(controlBarElement, prevEndTime/totalVideoTime, captions[i].startTime/totalVideoTime);
+        }
+        prevEndTime = captions[i].endTime;
+    }
+    // handle last caption to end
+    addRedRectangle(controlBarElement, prevEndTime/totalVideoTime, 1);
+}
 
 function setFastSpeed(){
     if(!document.isFastSpeed){

--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -1,8 +1,8 @@
 
 document.FAST_SPEED = 15;
 document.NORM_SPEED = 2;
-document.MIN_SKIP_TIME_UNTIL_NEXT_CAPTION = 2; // minimum length of silence until it is skipped
-document.START_SKIP_PADDING_TIME = 0.2; // padding to give until the skipping begins
+document.MIN_SKIP_TIME_UNTIL_NEXT_CAPTION = 1; // minimum length of silence until it is skipped
+document.START_SKIP_PADDING_TIME = 0.1; // padding to give until the skipping begins
 document.END_SKIP_PADDING_TIME = 0.1; // padding to give until the skipping ends
 
 async function tryFF(){

--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -21,7 +21,6 @@ async function tryFF(){
     const timeUntilNextCaption = document.ff_downtime_captions[document.lastCaptionIndex].startTime - getVideoElement().currentTime;
     const timeSinceLastSubtitle = document.lastCaptionIndex > 0 ? getVideoElement().currentTime-document.ff_downtime_captions[document.lastCaptionIndex-1].endTime:999;
 
-
     if(
         timeUntilNextCaption > document.MIN_SKIP_TIME_UNTIL_NEXT_CAPTION && 
         timeSinceLastSubtitle > document.START_SKIP_PADDING_TIME
@@ -177,8 +176,6 @@ function updateValuesOnPage(skipSpeed, normalSpeed) {
     const normalSpeedValue = normalSpeed !== undefined ? normalSpeed : '1';
 
     // Now you can use skipSpeedValue and normalSpeedValue as needed
-    // console.log('Skip Speed:', skipSpeedValue);
-    // console.log('Normal Speed:', normalSpeedValue);
     document.FAST_SPEED = skipSpeedValue;
     document.NORM_SPEED = normalSpeedValue;
 }
@@ -214,4 +211,3 @@ getCaptionsInterval = setInterval(()=>{
         pullVideoCaptions();
     }
 }, 100);
-

--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -184,11 +184,12 @@ function updateValuesOnPage(skipSpeed, normalSpeed) {
 }
 didAddSeekedEvent = false;
 getCaptionsInterval = setInterval(()=>{
-    if(!!getVideoElement() && !!getVideoCaptions() && didAddSeekedEvent){
+    if(!!getVideoElement() && !!getVideoCaptions() && didAddSeekedEvent && !isNaN(getVideoElement().duration)){
+        generateSkipPeriodsVisualization();
         clearInterval(getCaptionsInterval);
     }
 
-    if(getVideoElement() && !didAddSeekedEvent){
+    if(!!getVideoElement() && !didAddSeekedEvent){
         didAddSeekedEvent = true;
         injectCheckboxAndInterval();
         getVideoElement().addEventListener("seeked", ()=>{

--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -1,7 +1,9 @@
 
 document.FAST_SPEED = 15;
 document.NORM_SPEED = 2;
-
+document.MIN_SKIP_TIME_UNTIL_NEXT_CAPTION = 2; // minimum length of silence until it is skipped
+document.START_SKIP_PADDING_TIME = 0.2; // padding to give until the skipping begins
+document.END_SKIP_PADDING_TIME = 0.1; // padding to give until the skipping ends
 
 async function tryFF(){
     if(document.isFastSpeed){
@@ -20,9 +22,12 @@ async function tryFF(){
     const timeSinceLastSubtitle = document.lastCaptionIndex > 0 ? getVideoElement().currentTime-document.ff_downtime_captions[document.lastCaptionIndex-1].endTime:999;
 
 
-    if(timeUntilNextCaption > 2 && timeSinceLastSubtitle > 0.2){
+    if(
+        timeUntilNextCaption > document.MIN_SKIP_TIME_UNTIL_NEXT_CAPTION && 
+        timeSinceLastSubtitle > document.START_SKIP_PADDING_TIME
+        ){
         // ff to next time
-        const timeToSkipTo = document.ff_downtime_captions[document.lastCaptionIndex].startTime - 0.1;
+        const timeToSkipTo = document.ff_downtime_captions[document.lastCaptionIndex].startTime - document.END_SKIP_PADDING_TIME;
         
         if(document.skipSilenceMode){
             // skip to time

--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -40,6 +40,22 @@ async function tryFF(){
     }
 }
 
+function addRedRectangle(div, percentStart, percentEnd) {
+    const redRectangle = document.createElement('div');
+    redRectangle.style.position = 'absolute';
+    redRectangle.style.top = '0';
+    redRectangle.style.left = `${percentStart*100}%`;
+    redRectangle.style.height = '100%';
+    redRectangle.style.backgroundColor = 'rgba(100, 0, 0, 30)';
+    redRectangle.style.zIndex = '99'; // right under bubble
+    redRectangle.style.width = `${(percentEnd-percentStart)*100}%`;
+    
+    // Append the red rectangle to the container div
+    div.appendChild(redRectangle);
+    return redRectangle;//return for future ref
+  }
+
+
 function setFastSpeed(){
     if(!document.isFastSpeed){
         // console.log("Switched to fast speed.");

--- a/scripts/helper_functions.js
+++ b/scripts/helper_functions.js
@@ -87,6 +87,15 @@ function getVideoElement(){
         document.ff_downtime_video_element = k.contentDocument.getElementById(videoId);
     }
     return document.ff_downtime_video_element;
+    }
+    
+function getVideoSeekBarElement(){
+  if(!document.ff_downtime_video_seek_bar_element){
+    const k = document.getElementById("kaltura_player_ifp");
+    const sliderContainer = k.contentDocument.getElementsByClassName('controlBarContainer')[0];
+    document.ff_downtime_video_seek_bar_element = sliderContainer.querySelectorAll('[role="slider"]')[0];
+  }
+  return document.ff_downtime_video_seek_bar_element;
 }
 
 function getVideoCaptions() {


### PR DESCRIPTION
<img width="876" alt="image" src="https://github.com/WojtekTB/UCSD-Get-To-Yapping/assets/34536619/ec2f5bbd-cf6b-4cd0-a2a2-1d01f0043daf">

The video seek bar now has the periods that will be skipped marked in red. Also isolated the skip consts for minimum time for skip period and padding for easier customization and tweaking later.